### PR TITLE
feat: support disabling scheduled task, primarily for local dev and lower environments

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -9,5 +9,12 @@ export interface Config {
      * @visibility frontend
      */
     appId?: string;
+    /**
+     * Optionally disable data collection.
+     * Useful to disable collection in development environments with configuration overrides.
+     *
+     * @visibility backend
+     */
+    disableDataCollection?: boolean;
   };
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -74,6 +74,13 @@ function scheduleTask({
     initialDelay: schedule?.initialDelay ?? { seconds: 3 },
     scope: schedule?.scope ?? "global",
     fn: async () => {
+      const disable = config.getOptionalBoolean("dx.disableDataCollection");
+
+      if (disable) {
+        logger.info("DX Catalog sync is disabled");
+        return;
+      }
+
       logger.info("Starting DX Catalog sync");
 
       // TODO: Filter entities with extentionApi?


### PR DESCRIPTION
This adds an optional configuration value, `disableDataCollection` to disable running the data collection scheduled task.

This can be helpful for teams running multiple environments of backstage to disable data collection in a local environment or a development environment of backstage. 

The other way to do this is to conditionally install the plugin in the backend but using config can be more straightforward and helps to keeps installs more 12 factor and configuration driven. 