### PR TITLE
Support new backend system first w/ auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ DX Backstage plugin to automatically sync your Backstage data to DX Data Cloud.
 
 ## Setup
 
+> v2 of this plugin supports the [new backend system](https://backstage.io/docs/backend-system/) first, and deprecates support for the old backend system which will be removed in a future.
+
 1. Install this plugin in your backstage backend —
 
 ```bash
@@ -22,30 +24,18 @@ proxy:
         Authorization: Bearer ${DX_API_TOKEN}
 ```
 
-3. Add a new plugin file at `packages/backend/src/plugins/dx.ts` —
+3. In your `packages/backend/src/index.ts` file, make the following changes:
 
-```ts
-import { PluginEnvironment } from "../types";
-import { createRouter } from "@get-dx/backstage-backend-plugin";
+```diff
+  import { createBackend } from '@backstage/backend-defaults';
 
-export default async function createPlugin(env: PluginEnvironment) {
-  return await createRouter({
-    scheduler: env.scheduler,
-    logger: env.logger,
-    discovery: env.discovery,
-    config: env.config,
-  });
-}
-```
+  const backend = createBackend();
 
-4. Update your backend startup to include the DX plugin —
+  // ... other feature additions
 
-```ts
-import dx from "./plugins/dx";
-// ...
-const dxEnv = useHotMemoize(module, () => createEnv("dx"));
-// ...
-apiRouter.use("/dx", await dx(dxEnv));
++ backend.add(import('@get-dx/backstage-backend-plugin'));
+
+  backend.start();
 ```
 
 5. Deploy your backend!
@@ -60,24 +50,6 @@ Optionally set `catalogSyncAllowedKinds` to only send specific kinds of entities
 # app-config.yaml
 dx:
   catalogSyncAllowedKinds: [API, Component, User, Group]
-```
-
-### New Backend System
-
-The DX backend plugin has support for the [new backend system](https://backstage.io/docs/backend-system/), here's how you can set that up:
-
-In your packages/backend/src/index.ts make the following changes:
-
-```diff
-  import { createBackend } from '@backstage/backend-defaults';
-
-  const backend = createBackend();
-
-  // ... other feature additions
-
-+ backend.add(import('@get-dx/backstage-backend-plugin'));
-
-  backend.start();
 ```
 
 ### Schedule
@@ -101,19 +73,6 @@ The default schedule in [`TaskScheduleDefinition`](https://backstage.io/docs/ref
 | `timeout`      | `{ minutes: 2 }` |
 | `initialDelay` | `{ seconds: 3 }` |
 | `scope`        | `'global'`       |
-
-### Service to Service Auth
-
-If you are using backstage [service to service auth](https://backstage.io/docs/auth/service-to-service-auth) you can pass a `tokenManager` to the plugin to authenticate requests from the plugin to your Catalog and Proxy API.
-
-```ts
-export default async function createPlugin(env: PluginEnvironment) {
-  return await createRouter({
-    ...
-    tokenManager: env.tokenManager,
-  });
-}
-```
 
 ### Application Id
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/backstage-backend-plugin",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Backstage backend plugin for DX! https://getdx.com",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Support the new backend system first. 

Replaces tokenManager with auth.

Deprecates old backend system.

Removes deprecated task definition type.